### PR TITLE
Add support for Rails 5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,3 +24,16 @@ jobs:
             BUNDLE_GEMFILE: test/gemfiles/Gemfile.rails-4.2.x
           command: |
             bundle exec rake test
+
+      # run tests for rails 5.2
+      - run:
+          name: Install gems (5.2)
+          environment:
+            BUNDLE_GEMFILE: test/gemfiles/Gemfile.rails-5.2.x
+          command: bundle install
+      - run:
+          name: Run tests (5.2)
+          environment:
+            BUNDLE_GEMFILE: test/gemfiles/Gemfile.rails-5.2.x
+          command: |
+            bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.7 / 2018-7-27
+
+* support Rails 5.2
+
 # 1.0.6 / 2018-6-12
 
 * Update activesupport to 4.2.9

--- a/lib/hash_accessor.rb
+++ b/lib/hash_accessor.rb
@@ -4,7 +4,7 @@ $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname
 require 'hash_accessor/railtie' if defined?(Rails)
 
 module HashAccessor
-  VERSION = "1.0.6"
+  VERSION = "1.0.7"
 
   autoload :ClassMethods, 'hash_accessor/class_methods'
 

--- a/test/gemfiles/Gemfile.rails-5.2.x
+++ b/test/gemfiles/Gemfile.rails-5.2.x
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+gemspec :path => "./../.."
+
+gem "activesupport", "~> 5.2.0"
+gem 'coveralls', :require => false

--- a/test/hash_accessor_test.rb
+++ b/test/hash_accessor_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class HashAccessorTest < MiniTest::Unit::TestCase
+class HashAccessorTest < MiniTest::Test
 
   class TestClassWithHash
     include HashAccessor
@@ -40,7 +40,7 @@ class HashAccessorTest < MiniTest::Unit::TestCase
 
     assert_equal "some test", t1.unspecified_variable
     assert_equal [:blah], t1.test_array_2
-    assert_equal nil, t2.unspecified_variable
+    assert_nil t2.unspecified_variable
     assert_equal [], t2.test_array_2
   end
 


### PR DESCRIPTION
# What's in this PR
Replaced a deprecated method and updated where the HashAccessorTest is inheriting from.

Added a gemfile for installing and running tests using ActiveSupport 5.2.