### PR TITLE
Support Ruby 4

### DIFF
--- a/hash_accessor.gemspec
+++ b/hash_accessor.gemspec
@@ -22,6 +22,4 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_path  = "lib"
-
-  s.has_rdoc = true
 end

--- a/lib/hash_accessor.rb
+++ b/lib/hash_accessor.rb
@@ -4,7 +4,7 @@ $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname
 require 'hash_accessor/railtie' if defined?(Rails)
 
 module HashAccessor
-  VERSION = '1.0.8'
+  VERSION = '1.0.9'
 
   autoload :ClassMethods, 'hash_accessor/class_methods'
 


### PR DESCRIPTION
Remove `has_rdoc=` from gemspec since it has been removed in ruby 4. Update the gem version to 1.0.9.